### PR TITLE
[Lia] 유저 로그인(?) 및 게임 선택 화면 구현

### DIFF
--- a/iOS/baseball-game/baseball-game.xcodeproj/project.pbxproj
+++ b/iOS/baseball-game/baseball-game.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AE5C79AF2640E8710075EBC3 /* GameCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79AD2640E8710075EBC3 /* GameCell.swift */; };
 		AE5C79B02640E8710075EBC3 /* GameCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = AE5C79AE2640E8710075EBC3 /* GameCell.xib */; };
 		AE5C79B2264127300075EBC3 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79B1264127300075EBC3 /* Game.swift */; };
+		AE5C79B426412B830075EBC3 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79B326412B830075EBC3 /* Network.swift */; };
 		AE7A1542263FE4DE005EBAB9 /* SelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */; };
 		E4AA6883263FDDA500139BD6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6882263FDDA500139BD6 /* AppDelegate.swift */; };
 		E4AA6885263FDDA500139BD6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6884263FDDA500139BD6 /* SceneDelegate.swift */; };
@@ -23,6 +24,7 @@
 		AE5C79AD2640E8710075EBC3 /* GameCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCell.swift; sourceTree = "<group>"; };
 		AE5C79AE2640E8710075EBC3 /* GameCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GameCell.xib; sourceTree = "<group>"; };
 		AE5C79B1264127300075EBC3 /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
+		AE5C79B326412B830075EBC3 /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionViewController.swift; sourceTree = "<group>"; };
 		E4AA687F263FDDA500139BD6 /* baseball-game.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "baseball-game.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4AA6882263FDDA500139BD6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -45,6 +47,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AE5C79B526412B900075EBC3 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				AE5C79B326412B830075EBC3 /* Network.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 		AE7A1543263FE4FE005EBAB9 /* Selection */ = {
 			isa = PBXGroup;
 			children = (
@@ -77,6 +87,7 @@
 			children = (
 				E4AA6896263FDDD400139BD6 /* AppCycle */,
 				AE7A1543263FE4FE005EBAB9 /* Selection */,
+				AE5C79B526412B900075EBC3 /* Network */,
 				E4AA6886263FDDA500139BD6 /* ViewController.swift */,
 				E4AA6888263FDDA500139BD6 /* Main.storyboard */,
 				E4AA688B263FDDA800139BD6 /* Assets.xcassets */,
@@ -171,6 +182,7 @@
 				E4AA6887263FDDA500139BD6 /* ViewController.swift in Sources */,
 				AE7A1542263FE4DE005EBAB9 /* SelectionViewController.swift in Sources */,
 				E4AA6883263FDDA500139BD6 /* AppDelegate.swift in Sources */,
+				AE5C79B426412B830075EBC3 /* Network.swift in Sources */,
 				E4AA6885263FDDA500139BD6 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/baseball-game/baseball-game.xcodeproj/project.pbxproj
+++ b/iOS/baseball-game/baseball-game.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AE5C79B02640E8710075EBC3 /* GameCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = AE5C79AE2640E8710075EBC3 /* GameCell.xib */; };
 		AE5C79B2264127300075EBC3 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79B1264127300075EBC3 /* Game.swift */; };
 		AE5C79B426412B830075EBC3 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79B326412B830075EBC3 /* Network.swift */; };
+		AE5C79B7264138E70075EBC3 /* SelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79B6264138E70075EBC3 /* SelectViewModel.swift */; };
 		AE7A1542263FE4DE005EBAB9 /* SelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */; };
 		E4AA6883263FDDA500139BD6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6882263FDDA500139BD6 /* AppDelegate.swift */; };
 		E4AA6885263FDDA500139BD6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6884263FDDA500139BD6 /* SceneDelegate.swift */; };
@@ -25,6 +26,7 @@
 		AE5C79AE2640E8710075EBC3 /* GameCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GameCell.xib; sourceTree = "<group>"; };
 		AE5C79B1264127300075EBC3 /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
 		AE5C79B326412B830075EBC3 /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
+		AE5C79B6264138E70075EBC3 /* SelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectViewModel.swift; sourceTree = "<group>"; };
 		AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionViewController.swift; sourceTree = "<group>"; };
 		E4AA687F263FDDA500139BD6 /* baseball-game.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "baseball-game.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4AA6882263FDDA500139BD6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -59,9 +61,10 @@
 			isa = PBXGroup;
 			children = (
 				AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */,
-				AE5C79B1264127300075EBC3 /* Game.swift */,
+				AE5C79B6264138E70075EBC3 /* SelectViewModel.swift */,
 				AE5C79AD2640E8710075EBC3 /* GameCell.swift */,
 				AE5C79AE2640E8710075EBC3 /* GameCell.xib */,
+				AE5C79B1264127300075EBC3 /* Game.swift */,
 			);
 			path = Selection;
 			sourceTree = "<group>";
@@ -181,6 +184,7 @@
 				AE5C79B2264127300075EBC3 /* Game.swift in Sources */,
 				E4AA6887263FDDA500139BD6 /* ViewController.swift in Sources */,
 				AE7A1542263FE4DE005EBAB9 /* SelectionViewController.swift in Sources */,
+				AE5C79B7264138E70075EBC3 /* SelectViewModel.swift in Sources */,
 				E4AA6883263FDDA500139BD6 /* AppDelegate.swift in Sources */,
 				AE5C79B426412B830075EBC3 /* Network.swift in Sources */,
 				E4AA6885263FDDA500139BD6 /* SceneDelegate.swift in Sources */,

--- a/iOS/baseball-game/baseball-game.xcodeproj/project.pbxproj
+++ b/iOS/baseball-game/baseball-game.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AE5C79B426412B830075EBC3 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79B326412B830075EBC3 /* Network.swift */; };
 		AE5C79B7264138E70075EBC3 /* SelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79B6264138E70075EBC3 /* SelectViewModel.swift */; };
 		AE7A1542263FE4DE005EBAB9 /* SelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */; };
+		AEFE32DA2643971B0077AA5F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFE32D92643971B0077AA5F /* LoginViewController.swift */; };
 		E4AA6883263FDDA500139BD6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6882263FDDA500139BD6 /* AppDelegate.swift */; };
 		E4AA6885263FDDA500139BD6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6884263FDDA500139BD6 /* SceneDelegate.swift */; };
 		E4AA6887263FDDA500139BD6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6886263FDDA500139BD6 /* ViewController.swift */; };
@@ -28,6 +29,7 @@
 		AE5C79B326412B830075EBC3 /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		AE5C79B6264138E70075EBC3 /* SelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectViewModel.swift; sourceTree = "<group>"; };
 		AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionViewController.swift; sourceTree = "<group>"; };
+		AEFE32D92643971B0077AA5F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		E4AA687F263FDDA500139BD6 /* baseball-game.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "baseball-game.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4AA6882263FDDA500139BD6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4AA6884263FDDA500139BD6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -60,6 +62,7 @@
 		AE7A1543263FE4FE005EBAB9 /* Selection */ = {
 			isa = PBXGroup;
 			children = (
+				AEFE32D92643971B0077AA5F /* LoginViewController.swift */,
 				AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */,
 				AE5C79B6264138E70075EBC3 /* SelectViewModel.swift */,
 				AE5C79AD2640E8710075EBC3 /* GameCell.swift */,
@@ -180,6 +183,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AEFE32DA2643971B0077AA5F /* LoginViewController.swift in Sources */,
 				AE5C79AF2640E8710075EBC3 /* GameCell.swift in Sources */,
 				AE5C79B2264127300075EBC3 /* Game.swift in Sources */,
 				E4AA6887263FDDA500139BD6 /* ViewController.swift in Sources */,

--- a/iOS/baseball-game/baseball-game.xcodeproj/project.pbxproj
+++ b/iOS/baseball-game/baseball-game.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AE5C79AF2640E8710075EBC3 /* GameCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79AD2640E8710075EBC3 /* GameCell.swift */; };
+		AE5C79B02640E8710075EBC3 /* GameCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = AE5C79AE2640E8710075EBC3 /* GameCell.xib */; };
+		AE5C79B2264127300075EBC3 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5C79B1264127300075EBC3 /* Game.swift */; };
+		AE7A1542263FE4DE005EBAB9 /* SelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */; };
 		E4AA6883263FDDA500139BD6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6882263FDDA500139BD6 /* AppDelegate.swift */; };
 		E4AA6885263FDDA500139BD6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6884263FDDA500139BD6 /* SceneDelegate.swift */; };
 		E4AA6887263FDDA500139BD6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AA6886263FDDA500139BD6 /* ViewController.swift */; };
@@ -16,6 +20,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		AE5C79AD2640E8710075EBC3 /* GameCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCell.swift; sourceTree = "<group>"; };
+		AE5C79AE2640E8710075EBC3 /* GameCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GameCell.xib; sourceTree = "<group>"; };
+		AE5C79B1264127300075EBC3 /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
+		AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionViewController.swift; sourceTree = "<group>"; };
 		E4AA687F263FDDA500139BD6 /* baseball-game.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "baseball-game.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4AA6882263FDDA500139BD6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4AA6884263FDDA500139BD6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -37,6 +45,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AE7A1543263FE4FE005EBAB9 /* Selection */ = {
+			isa = PBXGroup;
+			children = (
+				AE7A1541263FE4DE005EBAB9 /* SelectionViewController.swift */,
+				AE5C79B1264127300075EBC3 /* Game.swift */,
+				AE5C79AD2640E8710075EBC3 /* GameCell.swift */,
+				AE5C79AE2640E8710075EBC3 /* GameCell.xib */,
+			);
+			path = Selection;
+			sourceTree = "<group>";
+		};
 		E4AA6876263FDDA500139BD6 = {
 			isa = PBXGroup;
 			children = (
@@ -57,6 +76,7 @@
 			isa = PBXGroup;
 			children = (
 				E4AA6896263FDDD400139BD6 /* AppCycle */,
+				AE7A1543263FE4FE005EBAB9 /* Selection */,
 				E4AA6886263FDDA500139BD6 /* ViewController.swift */,
 				E4AA6888263FDDA500139BD6 /* Main.storyboard */,
 				E4AA688B263FDDA800139BD6 /* Assets.xcassets */,
@@ -135,6 +155,7 @@
 				E4AA688F263FDDA800139BD6 /* LaunchScreen.storyboard in Resources */,
 				E4AA688C263FDDA800139BD6 /* Assets.xcassets in Resources */,
 				E4AA688A263FDDA500139BD6 /* Main.storyboard in Resources */,
+				AE5C79B02640E8710075EBC3 /* GameCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -145,7 +166,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AE5C79AF2640E8710075EBC3 /* GameCell.swift in Sources */,
+				AE5C79B2264127300075EBC3 /* Game.swift in Sources */,
 				E4AA6887263FDDA500139BD6 /* ViewController.swift in Sources */,
+				AE7A1542263FE4DE005EBAB9 /* SelectionViewController.swift in Sources */,
 				E4AA6883263FDDA500139BD6 /* AppDelegate.swift in Sources */,
 				E4AA6885263FDDA500139BD6 /* SceneDelegate.swift in Sources */,
 			);

--- a/iOS/baseball-game/baseball-game/AppCycle/SceneDelegate.swift
+++ b/iOS/baseball-game/baseball-game/AppCycle/SceneDelegate.swift
@@ -10,6 +10,17 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: windowScene)
 
+        let rootViewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(identifier: "LoginViewController") as LoginViewController
+
+        let navigationViewController = UINavigationController(rootViewController: rootViewController)
+
+        window?.rootViewController = navigationViewController
+    }
 }
 

--- a/iOS/baseball-game/baseball-game/Base.lproj/Main.storyboard
+++ b/iOS/baseball-game/baseball-game/Base.lproj/Main.storyboard
@@ -1,24 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Selection View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="SelectionViewController" customModule="baseball_game" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TEj-De-JFw">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="게임 목록" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZaK-Yz-YEw">
+                                <rect key="frame" x="146.5" y="74" width="121.5" height="39.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="33"/>
+                                <color key="textColor" systemColor="systemGray5Color"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="120" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Qom-Qz-GeO">
+                                <rect key="frame" x="10" y="158.5" width="394" height="658.5"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="120" id="pQd-GF-lQg">
+                                        <rect key="frame" x="0.0" y="24.5" width="394" height="120"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pQd-GF-lQg" id="l8i-ge-Lwi">
+                                            <rect key="frame" x="0.0" y="0.0" width="394" height="120"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" red="0.040723347715822478" green="0.09781032958678347" blue="0.18880824850063127" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="ZaK-Yz-YEw" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="30" id="Fs8-Bi-8jH"/>
+                            <constraint firstItem="Qom-Qz-GeO" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="10" id="Khu-x6-Cnc"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Qom-Qz-GeO" secondAttribute="trailing" constant="10" id="KvQ-2G-981"/>
+                            <constraint firstItem="Qom-Qz-GeO" firstAttribute="top" secondItem="ZaK-Yz-YEw" secondAttribute="bottom" constant="45" id="SgB-QY-JC0"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="Qom-Qz-GeO" secondAttribute="bottom" constant="45" id="THc-gh-Veh"/>
+                            <constraint firstItem="ZaK-Yz-YEw" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="X5R-nH-yDi"/>
+                            <constraint firstItem="TEj-De-JFw" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="iaF-GG-hhr"/>
+                            <constraint firstAttribute="bottom" secondItem="TEj-De-JFw" secondAttribute="bottom" id="jha-K5-GAK"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="TEj-De-JFw" secondAttribute="trailing" id="pKw-q4-jRU"/>
+                            <constraint firstItem="TEj-De-JFw" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="sdR-iG-9cO"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="backgroundView" destination="TEj-De-JFw" id="msw-kk-e3V"/>
+                        <outlet property="gameListTableView" destination="Qom-Qz-GeO" id="3md-l4-Ihh"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="131.8840579710145" y="114.50892857142857"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iOS/baseball-game/baseball-game/Base.lproj/Main.storyboard
+++ b/iOS/baseball-game/baseball-game/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bc6-zR-OBT">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
@@ -8,10 +8,53 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--Login View Controller-->
+        <scene sceneID="vgB-wA-gkL">
+            <objects>
+                <viewController storyboardIdentifier="LoginViewController" id="acG-MO-tPJ" customClass="LoginViewController" customModule="baseball_game" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Rbm-Wg-nXP">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ump-1U-kn2">
+                                <rect key="frame" x="106" y="287" width="202" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="로그인 해보시지" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zsQ-El-PkC">
+                                <rect key="frame" x="82" y="87" width="250" height="87"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fnZ-6B-4DN">
+                                <rect key="frame" x="161" y="358" width="92" height="66"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <state key="normal" title="확인"/>
+                                <connections>
+                                    <action selector="okButtonTouched:" destination="acG-MO-tPJ" eventType="touchUpInside" id="jde-2f-lwj"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="usz-km-bvy"/>
+                        <color key="backgroundColor" systemColor="systemGray6Color"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="aMp-h1-3sO"/>
+                    <connections>
+                        <outlet property="IDTextField" destination="ump-1U-kn2" id="0Xr-ng-afF"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="XGK-4h-xgL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="84.057971014492765" y="114.50892857142857"/>
+        </scene>
         <!--Selection View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="SelectionViewController" customModule="baseball_game" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SelectionViewController" id="BYZ-38-t0r" customClass="SelectionViewController" customModule="baseball_game" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -56,6 +99,7 @@
                             <constraint firstItem="TEj-De-JFw" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="sdR-iG-9cO"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="pCT-Ol-cD7"/>
                     <connections>
                         <outlet property="backgroundView" destination="TEj-De-JFw" id="msw-kk-e3V"/>
                         <outlet property="gameListTableView" destination="Qom-Qz-GeO" id="3md-l4-Ihh"/>
@@ -63,12 +107,33 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="131.8840579710145" y="114.50892857142857"/>
+            <point key="canvasLocation" x="1042.0289855072465" y="114.50892857142857"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="V5N-W2-hhL">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="bc6-zR-OBT" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="CfT-9w-1yW">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="acG-MO-tPJ" kind="relationship" relationship="rootViewController" id="5nd-sF-m8A"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iIS-6P-iFA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-826.08695652173924" y="114.50892857142857"/>
         </scene>
     </scenes>
     <resources>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOS/baseball-game/baseball-game/Info.plist
+++ b/iOS/baseball-game/baseball-game/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/iOS/baseball-game/baseball-game/Network/Network.swift
+++ b/iOS/baseball-game/baseball-game/Network/Network.swift
@@ -1,0 +1,51 @@
+//
+//  Network.swift
+//  baseball-game
+//
+//  Created by Lia on 2021/05/04.
+//
+
+import Foundation
+import Combine
+
+enum NetworkError: Error {
+    case BadURL
+    case DecodingError
+}
+
+enum EndPoint {
+    static let scheme = "https"
+    static let host = "28620c3c-a2bb-4264-bf32-8546221c8a8d.mock.pstmn.io"
+    static let path = "/baseball/games"
+    
+    static func url(path: String) -> URL? {
+        var components = URLComponents()
+        
+        components.scheme = EndPoint.scheme
+        components.host = EndPoint.host
+        components.path = "\(EndPoint.path)\(path)"
+        
+        return components.url
+    }
+}
+
+
+class NetworkManager {
+    
+    func request<T: Decodable>(type: T.Type, url: URL) -> AnyPublisher<T, Error> {
+        
+        return URLSession.shared.dataTaskPublisher(for: url)
+            .tryMap { element -> Data in
+                guard let httpResponse = element.response as? HTTPURLResponse,
+                    httpResponse.statusCode == 200 else {
+                    throw NetworkError.BadURL
+                    }
+                return element.data
+            }
+            .decode(type: T.self, decoder: JSONDecoder())
+            .mapError({ (error) -> Error in
+                return error
+            })
+            .eraseToAnyPublisher()
+    }
+}

--- a/iOS/baseball-game/baseball-game/Network/Network.swift
+++ b/iOS/baseball-game/baseball-game/Network/Network.swift
@@ -32,7 +32,7 @@ enum EndPoint {
 
 class NetworkManager {
     
-    func request<T: Decodable>(type: T.Type, url: URL) -> AnyPublisher<T, Error> {
+    static func request<T: Decodable>(type: T.Type, url: URL) -> AnyPublisher<T, Error> {
         
         return URLSession.shared.dataTaskPublisher(for: url)
             .tryMap { element -> Data in

--- a/iOS/baseball-game/baseball-game/Selection/Game.swift
+++ b/iOS/baseball-game/baseball-game/Selection/Game.swift
@@ -7,13 +7,18 @@
 
 import Foundation
 
-struct Game: Hashable, Decodable {
+struct Game: Hashable, Codable {
     let id: Int
     let home: Team
     let away: Team
 }
 
-struct Team: Hashable, Decodable {
+struct Team: Hashable, Codable {
     let team: String
     let status: String
+}
+
+struct Info: Codable {
+    let userID: String
+    let game: Game
 }

--- a/iOS/baseball-game/baseball-game/Selection/Game.swift
+++ b/iOS/baseball-game/baseball-game/Selection/Game.swift
@@ -7,19 +7,13 @@
 
 import Foundation
 
-struct Game: Hashable {
+struct Game: Hashable, Decodable {
     let id: Int
-    let home: String
-    let away: String
-    let selectable: Bool
+    let home: Team
+    let away: Team
 }
 
-
-let game1 = Game(id: 1, home: "Marvel", away: "Captin", selectable: true)
-let game2 = Game(id: 2, home: "Tigers", away: "Twins", selectable: false)
-let game3 = Game(id: 3, home: "Dodgers", away: "Rockets", selectable: false)
-let game4 = Game(id: 4, home: "Pintos", away: "Heros", selectable: false)
-let game5 = Game(id: 5, home: "LiaTigers", away: "LolloTwins", selectable: true)
-let game6 = Game(id: 6, home: "Shion", away: "KalTwoi", selectable: true)
-
-let games = [game1, game2, game3, game4, game5, game6]
+struct Team: Hashable, Decodable {
+    let team: String
+    let status: String
+}

--- a/iOS/baseball-game/baseball-game/Selection/Game.swift
+++ b/iOS/baseball-game/baseball-game/Selection/Game.swift
@@ -7,18 +7,19 @@
 
 import Foundation
 
-struct Game: Hashable, Codable {
-    let id: Int
-    let home: Team
-    let away: Team
+struct Game: Codable, Hashable {
+    var id: Int = 0
+    var home: Team = Team()
+    var away: Team = Team()
 }
 
-struct Team: Hashable, Codable {
-    let team: String
-    let status: String
+struct Team: Codable, Hashable {
+    var team: String = ""
+    var status: String = ""
 }
 
-struct Info: Codable {
-    let userID: String
-    let game: Game
+struct GameInfo: Codable {
+    var userID: String = ""
+    var gameID: Int = 0
+    var team: String = ""
 }

--- a/iOS/baseball-game/baseball-game/Selection/Game.swift
+++ b/iOS/baseball-game/baseball-game/Selection/Game.swift
@@ -1,0 +1,25 @@
+//
+//  Game.swift
+//  baseball-game
+//
+//  Created by Lia on 2021/05/04.
+//
+
+import Foundation
+
+struct Game: Hashable {
+    let id: Int
+    let home: String
+    let away: String
+    let selectable: Bool
+}
+
+
+let game1 = Game(id: 1, home: "Marvel", away: "Captin", selectable: true)
+let game2 = Game(id: 2, home: "Tigers", away: "Twins", selectable: false)
+let game3 = Game(id: 3, home: "Dodgers", away: "Rockets", selectable: false)
+let game4 = Game(id: 4, home: "Pintos", away: "Heros", selectable: false)
+let game5 = Game(id: 5, home: "LiaTigers", away: "LolloTwins", selectable: true)
+let game6 = Game(id: 6, home: "Shion", away: "KalTwoi", selectable: true)
+
+let games = [game1, game2, game3, game4, game5, game6]

--- a/iOS/baseball-game/baseball-game/Selection/GameCell.swift
+++ b/iOS/baseball-game/baseball-game/Selection/GameCell.swift
@@ -25,11 +25,11 @@ class GameCell: UITableViewCell {
     
     func fill(state: Game) {
         self.gameIdLabel.text = "GAME \(state.id)"
-        self.awayTeamButton.setTitle(state.away, for: .normal)
-        self.homeTeamButton.setTitle(state.home, for: .normal)
+        self.awayTeamButton.setTitle(state.away.team, for: .normal)
+        self.homeTeamButton.setTitle(state.home.team, for: .normal)
         
-        self.awayTeam = state.away
-        self.homeTeam = state.home
+        self.awayTeam = state.away.team
+        self.homeTeam = state.home.team
     }
     
 }

--- a/iOS/baseball-game/baseball-game/Selection/GameCell.swift
+++ b/iOS/baseball-game/baseball-game/Selection/GameCell.swift
@@ -1,0 +1,35 @@
+//
+//  GameCell.swift
+//  baseball-game
+//
+//  Created by Lia on 2021/05/04.
+//
+
+import UIKit
+
+class GameCell: UITableViewCell {
+    static let reuseIdentifier = "GameCell"
+    static let nib = UINib(nibName: GameCell.reuseIdentifier, bundle: nil)
+    
+    @IBOutlet weak var gameIdLabel: UILabel!
+    @IBOutlet weak var awayTeamButton: UIButton!
+    @IBOutlet weak var homeTeamButton: UIButton!
+    
+    private var awayTeam: String!
+    private var homeTeam: String!
+    
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    func fill(state: Game) {
+        self.gameIdLabel.text = "GAME \(state.id)"
+        self.awayTeamButton.setTitle(state.away, for: .normal)
+        self.homeTeamButton.setTitle(state.home, for: .normal)
+        
+        self.awayTeam = state.away
+        self.homeTeam = state.home
+    }
+    
+}

--- a/iOS/baseball-game/baseball-game/Selection/GameCell.swift
+++ b/iOS/baseball-game/baseball-game/Selection/GameCell.swift
@@ -11,10 +11,13 @@ class GameCell: UITableViewCell {
     static let reuseIdentifier = "GameCell"
     static let nib = UINib(nibName: GameCell.reuseIdentifier, bundle: nil)
     
+    private var viewModel: SelectViewModel!
+    
     @IBOutlet weak var gameIdLabel: UILabel!
     @IBOutlet weak var awayTeamButton: UIButton!
     @IBOutlet weak var homeTeamButton: UIButton!
     
+    private var gameInfo = GameInfo()
     private var awayTeam: String!
     private var homeTeam: String!
     
@@ -23,13 +26,37 @@ class GameCell: UITableViewCell {
         super.awakeFromNib()
     }
     
-    func fill(state: Game) {
+    func fill(_ viewModel: SelectViewModel, state: Game) {
+        self.viewModel = viewModel
+        self.gameInfo = GameInfo(userID: viewModel.gameInfo.userID, gameID: state.id)
+        
         self.gameIdLabel.text = "GAME \(state.id)"
         self.awayTeamButton.setTitle(state.away.team, for: .normal)
         self.homeTeamButton.setTitle(state.home.team, for: .normal)
+        self.setIsEnabled(state: state)
         
         self.awayTeam = state.away.team
         self.homeTeam = state.home.team
+    }
+    
+    private func setIsEnabled(state: Game) {
+        if state.away.status == "selected" { self.awayTeamButton.isEnabled = false }
+        if state.home.status == "selected" { self.homeTeamButton.isEnabled = false }
+    }
+    
+    @IBAction func awayButtonTouched(_ sender: UIButton) {
+        self.gameInfo.team = self.awayTeam
+        self.viewModel.setModel(with: self.gameInfo)
+        self.viewModel.postSelection(with: self.gameInfo)
+        self.awayTeamButton.isEnabled = false
+        
+    }
+    
+    @IBAction func homeButtonTouched(_ sender: UIButton) {
+        self.gameInfo.team = self.homeTeam
+        self.viewModel.setModel(with: self.gameInfo)
+        self.viewModel.postSelection(with: self.gameInfo)
+        self.homeTeamButton.isEnabled = false
     }
     
 }

--- a/iOS/baseball-game/baseball-game/Selection/GameCell.xib
+++ b/iOS/baseball-game/baseball-game/Selection/GameCell.xib
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="123" id="KGk-i7-Jjw" customClass="GameCell" customModule="baseball_game" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="374" height="123"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="374" height="123"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view alpha="0.59999999999999998" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rTK-fc-5AD">
+                        <rect key="frame" x="5" y="10" width="364" height="103"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.clipToBound" value="YES"/>
+                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                <integer key="value" value="10"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GAME 1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDN-HH-zAx">
+                        <rect key="frame" x="160.5" y="20" width="53" height="18"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <color key="textColor" red="0.67303528448547978" green="0.22017628758854807" blue="0.17600560015978661" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKO-Vg-juT">
+                        <rect key="frame" x="173" y="63" width="28" height="26"/>
+                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UCT-iC-Q4l">
+                        <rect key="frame" x="5" y="46" width="168" height="67"/>
+                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="28"/>
+                        <state key="normal" title="Captin">
+                            <color key="titleColor" systemColor="labelColor"/>
+                        </state>
+                    </button>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bGM-8n-Dyj">
+                        <rect key="frame" x="201" y="46" width="168" height="67"/>
+                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="28"/>
+                        <state key="normal" title="Marvel">
+                            <color key="titleColor" systemColor="labelColor"/>
+                        </state>
+                    </button>
+                </subviews>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                <constraints>
+                    <constraint firstItem="gKO-Vg-juT" firstAttribute="top" secondItem="hDN-HH-zAx" secondAttribute="bottom" constant="25" id="0cy-xa-Nb9"/>
+                    <constraint firstItem="rTK-fc-5AD" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="5" id="110-wE-ijp"/>
+                    <constraint firstItem="rTK-fc-5AD" firstAttribute="bottom" secondItem="UCT-iC-Q4l" secondAttribute="bottom" id="2kW-1J-wVS"/>
+                    <constraint firstAttribute="bottom" secondItem="rTK-fc-5AD" secondAttribute="bottom" constant="10" id="5sn-V5-Dvx"/>
+                    <constraint firstItem="bGM-8n-Dyj" firstAttribute="top" secondItem="hDN-HH-zAx" secondAttribute="bottom" constant="8" id="Fw9-eB-cjz"/>
+                    <constraint firstItem="UCT-iC-Q4l" firstAttribute="leading" secondItem="rTK-fc-5AD" secondAttribute="leading" id="H7X-Dt-Y80"/>
+                    <constraint firstItem="bGM-8n-Dyj" firstAttribute="leading" secondItem="gKO-Vg-juT" secondAttribute="trailing" id="MHd-Fa-Fss"/>
+                    <constraint firstItem="rTK-fc-5AD" firstAttribute="bottom" secondItem="bGM-8n-Dyj" secondAttribute="bottom" id="RW8-4H-olz"/>
+                    <constraint firstItem="UCT-iC-Q4l" firstAttribute="top" secondItem="hDN-HH-zAx" secondAttribute="bottom" constant="8" id="S4N-8S-HXW"/>
+                    <constraint firstItem="rTK-fc-5AD" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="S6o-oq-0uy"/>
+                    <constraint firstItem="hDN-HH-zAx" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="XhB-Q4-rfE"/>
+                    <constraint firstItem="rTK-fc-5AD" firstAttribute="trailing" secondItem="bGM-8n-Dyj" secondAttribute="trailing" id="cNM-nf-pot"/>
+                    <constraint firstItem="rTK-fc-5AD" firstAttribute="top" secondItem="hDN-HH-zAx" secondAttribute="top" constant="-10" id="d7u-eM-TdQ"/>
+                    <constraint firstItem="gKO-Vg-juT" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="jZc-B5-OMs"/>
+                    <constraint firstItem="gKO-Vg-juT" firstAttribute="leading" secondItem="UCT-iC-Q4l" secondAttribute="trailing" id="kdY-OX-W5i"/>
+                    <constraint firstAttribute="trailing" secondItem="rTK-fc-5AD" secondAttribute="trailing" constant="5" id="sC2-nr-DnG"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="awayTeamButton" destination="UCT-iC-Q4l" id="0tZ-m7-8Hr"/>
+                <outlet property="gameIdLabel" destination="hDN-HH-zAx" id="uHH-yd-7ve"/>
+                <outlet property="homeTeamButton" destination="bGM-8n-Dyj" id="bo7-o9-7Tr"/>
+            </connections>
+            <point key="canvasLocation" x="-2.8985507246376816" y="156.36160714285714"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOS/baseball-game/baseball-game/Selection/GameCell.xib
+++ b/iOS/baseball-game/baseball-game/Selection/GameCell.xib
@@ -45,6 +45,9 @@
                         <state key="normal" title="Captin">
                             <color key="titleColor" systemColor="labelColor"/>
                         </state>
+                        <connections>
+                            <action selector="awayButtonTouched:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Bye-JP-eFE"/>
+                        </connections>
                     </button>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bGM-8n-Dyj">
                         <rect key="frame" x="201" y="46" width="168" height="67"/>
@@ -52,6 +55,9 @@
                         <state key="normal" title="Marvel">
                             <color key="titleColor" systemColor="labelColor"/>
                         </state>
+                        <connections>
+                            <action selector="homeButtonTouched:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="l5H-pZ-3eP"/>
+                        </connections>
                     </button>
                 </subviews>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/iOS/baseball-game/baseball-game/Selection/LoginViewController.swift
+++ b/iOS/baseball-game/baseball-game/Selection/LoginViewController.swift
@@ -12,11 +12,10 @@ class LoginViewController: UIViewController {
     @IBOutlet weak var IDTextField: UITextField!
     
     @IBAction func okButtonTouched(_ sender: UIButton) {
-        let tempGame = Game(id: -1, home: Team(team: "", status: ""), away: Team(team: "", status: ""))
-        let gameInfo = Info(userID: IDTextField.text ?? "", game: tempGame)
+        let gameInfo = GameInfo(userID: IDTextField.text ?? "", team: "")
         
         guard let nextVC = storyboard?.instantiateViewController(withIdentifier: "SelectionViewController") as? SelectionViewController else { return }
-        nextVC.gameInfo = gameInfo
+        nextVC.viewModel.setModel(with: gameInfo)
         self.navigationController?.pushViewController(nextVC, animated: false)
     }
     

--- a/iOS/baseball-game/baseball-game/Selection/LoginViewController.swift
+++ b/iOS/baseball-game/baseball-game/Selection/LoginViewController.swift
@@ -1,0 +1,23 @@
+//
+//  LoginViewController.swift
+//  baseball-game
+//
+//  Created by Lia on 2021/05/06.
+//
+
+import UIKit
+
+class LoginViewController: UIViewController {
+    
+    @IBOutlet weak var IDTextField: UITextField!
+    
+    @IBAction func okButtonTouched(_ sender: UIButton) {
+        let tempGame = Game(id: -1, home: Team(team: "", status: ""), away: Team(team: "", status: ""))
+        let gameInfo = Info(userID: IDTextField.text ?? "", game: tempGame)
+        
+        guard let nextVC = storyboard?.instantiateViewController(withIdentifier: "SelectionViewController") as? SelectionViewController else { return }
+        nextVC.gameInfo = gameInfo
+        self.navigationController?.pushViewController(nextVC, animated: false)
+    }
+    
+}

--- a/iOS/baseball-game/baseball-game/Selection/SelectViewModel.swift
+++ b/iOS/baseball-game/baseball-game/Selection/SelectViewModel.swift
@@ -9,7 +9,15 @@ import Foundation
 import Combine
 
 class SelectViewModel {
+    private(set) var gameInfo: GameInfo!
     private var cancellable = Set<AnyCancellable>()
+    
+    
+    func setModel(with gameInfo: GameInfo) {
+        self.gameInfo = gameInfo
+    }
+    
+    //MARK: GET
     
     func request() {
         NetworkManager.request(type: [Game].self, url: EndPoint.url(path: "")!)
@@ -33,6 +41,19 @@ class SelectViewModel {
                 completion(userInfo["games"] ?? [])
             }.store(in: &cancellable)
     }
+    
+    //MARK: POST
+    func postSelection(with gameInfo: GameInfo) {
+        NetworkManager.post(url: EndPoint.url(path: "")!, data: gameInfo)
+            .receive(on: DispatchQueue.main)
+            .sink { error in
+                print(error)
+            } receiveValue: { _ in
+                print("success")
+            }
+            .store(in: &cancellable)
+    }
+    
 }
 
 enum NotificationName {

--- a/iOS/baseball-game/baseball-game/Selection/SelectViewModel.swift
+++ b/iOS/baseball-game/baseball-game/Selection/SelectViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  SelectViewModel.swift
+//  baseball-game
+//
+//  Created by Lia on 2021/05/04.
+//
+
+import Foundation
+import Combine
+
+

--- a/iOS/baseball-game/baseball-game/Selection/SelectViewModel.swift
+++ b/iOS/baseball-game/baseball-game/Selection/SelectViewModel.swift
@@ -8,4 +8,33 @@
 import Foundation
 import Combine
 
+class SelectViewModel {
+    private var cancellable = Set<AnyCancellable>()
+    
+    func request() {
+        NetworkManager.request(type: [Game].self, url: EndPoint.url(path: "")!)
+            .receive(on: DispatchQueue.main)
+            .sink { error in
+                print(error)
+            } receiveValue: { games in
+                self.fetch(data: games)
+            }
+            .store(in: &cancellable)
+    }
+    
+    private func fetch(data: [Game]) {
+        NotificationCenter.default.post(name: NotificationName.fetched, object: nil, userInfo: ["games": data])
+    }
+    
+    func didFetchData(completion: @escaping ([Game]) -> Void) {
+        NotificationCenter.default.publisher(for: NotificationName.fetched)
+            .map{ ($0.userInfo as! [String:[Game]]) }
+            .sink { (userInfo) in
+                completion(userInfo["games"] ?? [])
+            }.store(in: &cancellable)
+    }
+}
 
+enum NotificationName {
+    static let fetched = Notification.Name("fetched")
+}

--- a/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
+++ b/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
@@ -12,9 +12,10 @@ class SelectionViewController: UIViewController {
     @IBOutlet weak var backgroundView: UIView!
     @IBOutlet weak var gameListTableView: UITableView!
     
-    let gradientLayer: CAGradientLayer = CAGradientLayer()
+    private let gradientLayer: CAGradientLayer = CAGradientLayer()
     
     private var viewModel = SelectViewModel()
+    var gameInfo: Info!
     private var dataSource: UITableViewDiffableDataSource<Section, Game>!
     
     

--- a/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
+++ b/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
@@ -14,13 +14,15 @@ class SelectionViewController: UIViewController {
     
     let gradientLayer: CAGradientLayer = CAGradientLayer()
     
-    private var dataSource : UITableViewDiffableDataSource<Section, Game>!
+    private var viewModel = SelectViewModel()
+    private var dataSource: UITableViewDiffableDataSource<Section, Game>!
     
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setBackground()
         
+        self.viewModel.request()
         self.registerNib()
         self.configureDataSource()
         self.createSnapshot()
@@ -51,7 +53,9 @@ extension SelectionViewController {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Game>()
         
         snapshot.appendSections([.main])
-        snapshot.appendItems(games)
+        viewModel.didFetchData { games in
+            snapshot.appendItems(games)
+        }
         self.dataSource.apply(snapshot)
     }
 }

--- a/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
+++ b/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
@@ -14,8 +14,7 @@ class SelectionViewController: UIViewController {
     
     private let gradientLayer: CAGradientLayer = CAGradientLayer()
     
-    private var viewModel = SelectViewModel()
-    var gameInfo: Info!
+    var viewModel = SelectViewModel()
     private var dataSource: UITableViewDiffableDataSource<Section, Game>!
     
     
@@ -44,7 +43,7 @@ extension SelectionViewController {
         self.dataSource = UITableViewDiffableDataSource.init(tableView: self.gameListTableView) { (tableView, indexPath, game) -> UITableViewCell in
             
             let cell = self.gameListTableView.dequeueReusableCell(withIdentifier: GameCell.reuseIdentifier) as! GameCell
-            cell.fill(state: game)
+            cell.fill(self.viewModel, state: game)
             
             return cell
         }

--- a/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
+++ b/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
@@ -1,0 +1,69 @@
+//
+//  SelectionViewController.swift
+//  baseball-game
+//
+//  Created by Lia on 2021/05/03.
+//
+
+import UIKit
+
+class SelectionViewController: UIViewController {
+
+    @IBOutlet weak var backgroundView: UIView!
+    @IBOutlet weak var gameListTableView: UITableView!
+    
+    let gradientLayer: CAGradientLayer = CAGradientLayer()
+    
+    private var dataSource : UITableViewDiffableDataSource<Section, Game>!
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setBackground()
+        
+        self.registerNib()
+        self.configureDataSource()
+        self.createSnapshot()
+    }
+}
+
+
+extension SelectionViewController {
+    enum Section {
+        case main
+    }
+    
+    private func registerNib() {
+        self.gameListTableView.register(GameCell.nib, forCellReuseIdentifier: GameCell.reuseIdentifier)
+    }
+    
+    private func configureDataSource() {
+        self.dataSource = UITableViewDiffableDataSource.init(tableView: self.gameListTableView) { (tableView, indexPath, game) -> UITableViewCell in
+            
+            let cell = self.gameListTableView.dequeueReusableCell(withIdentifier: GameCell.reuseIdentifier) as! GameCell
+            cell.fill(state: game)
+            
+            return cell
+        }
+    }
+    
+    private func createSnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Game>()
+        
+        snapshot.appendSections([.main])
+        snapshot.appendItems(games)
+        self.dataSource.apply(snapshot)
+    }
+}
+
+
+extension SelectionViewController {
+
+    private func setBackground() {
+        self.gradientLayer.colors = [#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1).cgColor, #colorLiteral(red: 0.06274510175, green: 0, blue: 0.1921568662, alpha: 1).cgColor, #colorLiteral(red: 0.1921568662, green: 0.007843137719, blue: 0.09019608051, alpha: 1).cgColor, #colorLiteral(red: 0.06274510175, green: 0, blue: 0.1921568662, alpha: 1).cgColor, #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1).cgColor]
+        self.gradientLayer.startPoint = CGPoint(x: 0, y: 0)
+        self.gradientLayer.endPoint = CGPoint(x: 1, y: 1)
+        self.gradientLayer.frame = self.view.bounds
+        self.backgroundView.layer.addSublayer(self.gradientLayer)
+    }
+}

--- a/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
+++ b/iOS/baseball-game/baseball-game/Selection/SelectionViewController.swift
@@ -55,8 +55,8 @@ extension SelectionViewController {
         snapshot.appendSections([.main])
         viewModel.didFetchData { games in
             snapshot.appendItems(games)
+            self.dataSource.apply(snapshot)
         }
-        self.dataSource.apply(snapshot)
     }
 }
 


### PR DESCRIPTION
## 작업 목록
- [x] diffableDataSource 로 테이블뷰 구현
- [x] xib로 cell 구현
- [x] 모든 기기 화면 대응 (autoLayout) → 왜인지 성공..?
- [x] background 그라데이션
- [x] 네트워크 구현 (combine)
- [x] GET :  팀 목록 받기
- [x] selected/unselected 에 따라 버튼 비활성화 로직 구현
- [x] 셀과 뷰컨 사이 정보 전달 (유저 & 팀 정보) - delegate or notification
- [x] POST : 유저 & 팀
- [x] 간단한 user 로그인 
- [ ] 다음 화면으로 이동 (delegate)

## 고민 및 해결

> 고민

cell 선택 → user info & game info 를 서버에 POST하고, 다음 ViewController에 전달하는 방식
1.  diffableDataSource 로 콜렉션 뷰를 복잡하게 만들고  `didSelect` → cell 안에서도 팀이 두 개로 나뉘어서 사용자 입력을 받음 → 오바임
2. responder를 학습하고 적용하기?
3. 테이블뷰 안에 버튼을 넣고 버튼 터치 시 액션 진행

> 선택 방법

👉🏻 테이블뷰 안에 버튼 넣고 버튼 터치 시 액션 진행

> 적용 방법
- userID 를 ViewModel의 gameInfo 에 저장
- ViewModel 값을 cell 에 전달
- cell 내부에서 버튼 터치 시, post & 다음 뷰컨에 데이터 전달

> 추가 고려사항
- button을 title 읽는 대신, 내부에 홈팀, 원정팀 데이터를 저장한다

